### PR TITLE
Allow using opened IO object as `TSV::parse` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ Or install it yourself as:
 
 #### TSV::parse
 
-`TSV.parse` accepts TSV as a whole string, returning lazy enumerator, yielding TSV::Row objects on demand
+`TSV.parse` accepts basically anything that can enumerate over lines, for example:
+
+* TSV as a whole string
+* any IO object - a TSV file pre-opened with `File.open`, `StringIO` buffer containing TSV data, etc
+
+It returns a lazy enumerator, yielding TSV::Row objects on demand.
 
 #### TSV::parse_file
 

--- a/lib/tsv/cyclist.rb
+++ b/lib/tsv/cyclist.rb
@@ -9,7 +9,7 @@ module TSV
 
     def initialize(source, params = {}, &block)
       self.header   = params.fetch(:header, true)
-      self.source = source.to_s
+      self.source = source
       self.enumerator.each(&block) if block_given?
     end
 
@@ -59,7 +59,7 @@ module TSV
     alias :filepath :source
 
     def data_enumerator
-      File.new(self.source).each_line
+      File.new(self.source.to_s).each_line
     end
   end
 

--- a/spec/lib/tsv_spec.rb
+++ b/spec/lib/tsv_spec.rb
@@ -5,21 +5,48 @@ describe TSV do
 
   describe "#parse" do
     let(:header) { nil }
-    let(:content) { IO.read(File.join(File.dirname(__FILE__), '..', 'fixtures', filename)) }
     let(:parameters) { { header: header } }
 
-    subject { TSV.parse(content, parameters) }
+    context "given a string with content" do
+      let(:content) { IO.read(File.join(File.dirname(__FILE__), '..', 'fixtures', filename)) }
 
-    it "returns String Cyclist initialized with given data" do
-      expect(subject).to be_a TSV::StringCyclist
-      expect(subject.source).to eq(content)
+      subject { TSV.parse(content, parameters) }
+
+      it "returns String Cyclist initialized with given data" do
+        expect(subject).to be_a TSV::StringCyclist
+        expect(subject.source).to eq(content)
+      end
+
+      context "when block is given" do
+        it "passes block to Cyclist" do
+          data = []
+
+          TSV.parse(content) do |i|
+            data.push i
+          end
+
+          headers = %w{first second third}
+          expect(data).to eq [ TSV::Row.new( ['0', '1', '2'], headers ),
+                               TSV::Row.new( ['one', 'two', 'three'], headers ),
+                               TSV::Row.new( ['weird data', 's@mthin#', 'else'], headers ) ]
+        end
+      end
     end
 
-    context "when block is given" do
-      it "passes block to Cyclist" do
+    context "given a opened IO object" do
+      let(:content) { File.open(File.join(File.dirname(__FILE__), '..', 'fixtures', filename), 'r') }
+
+      subject { TSV.parse(content, parameters) }
+
+      it "returns String Cyclist initialized with given data" do
+        expect(subject).to be_a TSV::StringCyclist
+        expect(subject.source).to eq(content)
+      end
+
+      it "can properly parse file" do
         data = []
-        
-        TSV.parse(content) do |i|
+
+        TSV.parse(content).each do |i|
           data.push i
         end
 


### PR DESCRIPTION
This is an enhancement of high-level API that allows to use not only strings, fully pre-loaded into memory, but really any suitable object that has `#each_line`. First and foremost, it makes it possible to use pre-opened IO objects, for example, something like that:

```ruby
file = params['myfile'][:tempfile]
file.set_encoding('utf-8')
TSV::parse(file).each { |row|
  ...
}
```

where that `[:tempfile]` stuff is a pre-opened `TempFile` object made by user web file upload.